### PR TITLE
[TASK-69] fix: CanvasUnit 이동범위 재설정

### DIFF
--- a/src/components/CanvasContainer/index.jsx
+++ b/src/components/CanvasContainer/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { BsDownload, BsToggleOn, BsToggleOff } from "react-icons/bs";
 
@@ -7,6 +8,8 @@ import CanvasUnit from "../CanvasUnit";
 import Button from "../Button";
 
 const CanvasContainer = ({ style, elements }) => {
+  const navigate = useNavigate();
+
   const canvasRefs = {
     headCanvas: useRef(null),
     faceCanvas: useRef(null),
@@ -150,7 +153,11 @@ const CanvasContainer = ({ style, elements }) => {
           Download
         </Button>
         <Button
-          onClick={handleSketchSave}
+          onClick={() => {
+            handleSketchSave();
+
+            navigate("/my-sketches");
+          }}
           style={`
                   flex items-center 
                   justify-center bg-blue-500 

--- a/src/components/ParentCanvas/index.jsx
+++ b/src/components/ParentCanvas/index.jsx
@@ -18,7 +18,7 @@ const ParentCanvas = ({ width, height, children }) => {
           ref={canvasRef}
           width={width}
           height={height}
-          style={{ position: "relative", margin: "20px" }}
+          style={{ position: "relative", marginBottom: "20px" }}
         />
         {children}
       </div>


### PR DESCRIPTION
## 작업 요약
* CanvasUnit을 드래그로 이동시킬 때 ParentCanvas의 범위를 벗어나는 현상을 개선했습니다.

## 참고 사항
* 없습니다.

## 체크 리스트

- [x] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [x] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [x] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
