### PR TITLE
test: SketchCard 테스트 추가

### DIFF
--- a/src/components/SketchCard/index.test.jsx
+++ b/src/components/SketchCard/index.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe } from "vitest";
+
+import SketchCard from "./index";
+
+describe("SketchCard Component", () => {
+  let mockSketch;
+
+  beforeEach(() => {
+    mockSketch = {
+      url: "https://example.com/image.png",
+      title: "Test Sketch",
+      createdAt: "2023-01-01T00:00:00Z",
+      updatedAt: "2023-01-01T00:00:00Z",
+    };
+  });
+
+  test("renders correctly with sketch data", () => {
+    render(<SketchCard sketch={mockSketch} />);
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", mockSketch.url);
+    expect(
+      screen.getByText(
+        `Created: ${new Date(mockSketch.createdAt).toLocaleString()}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Updated: ${new Date(mockSketch.updatedAt).toLocaleString()}`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Test Sketch/)).toBeInTheDocument();
+  });
+
+  test("renders correctly without sketch data", () => {
+    render(<SketchCard />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  test("calls onClick when clicked", () => {
+    const mockOnClick = vi.fn();
+
+    render(<SketchCard sketch={mockSketch} onClick={mockOnClick} />);
+
+    fireEvent.click(screen.getByRole("img"));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 작업 요약
<img width="888" alt="스크린샷 2023-10-09 오전 9 29 33" src="https://github.com/team-desire/hello-sketch-client/assets/124029691/71f44445-8883-4df0-a263-f42d026e076c">


## 참고 사항


## 체크 리스트

- [X] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [X] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [X] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
