### PR TITLE
[TASK-88] test: UnitSelectorContainer 컴포넌트 유닛 테스트 추가

### DIFF
--- a/src/components/NavBar/index.test.jsx
+++ b/src/components/NavBar/index.test.jsx
@@ -1,0 +1,79 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+
+import { describe, expect, vi } from "vitest";
+
+import NavBar from "./index";
+import { signOut } from "firebase/auth";
+
+window.alert = vi.fn();
+
+vi.mock("firebase/auth", () => ({
+  getAuth: vi.fn(() => ({})),
+  signOut: vi.fn(() => Promise.resolve("Mock sign out")),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  ...vi.importActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+beforeEach(() => {
+  sessionStorage.setItem("accessToken", "mocked_access_token");
+  window.sessionStorage.setItem("userPhotoURL", "url");
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe("<NavBar />", () => {
+  test("should display the dropdown menu after clicking the user avatar", () => {
+    render(<NavBar />);
+
+    const userAvatarButton = screen.getByAltText("userImage");
+    fireEvent.click(userAvatarButton);
+
+    const dropdownMenu = screen.getByRole("menu");
+    expect(dropdownMenu).toBeVisible();
+
+    fireEvent.click(userAvatarButton);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  test("should not render dropdown buttons when there is no 'sessionStorage.accessToken'", () => {
+    const { queryByText } = render(<NavBar />);
+
+    expect(queryByText("My Sketches")).toBeNull();
+  });
+
+  test("should logout and clear session storage when logout is clicked", async () => {
+    const { getByAltText, getByText } = render(<NavBar />);
+
+    const userImage = getByAltText("userImage");
+    fireEvent.click(userImage);
+
+    const logoutButton = getByText("Logout");
+    fireEvent.click(logoutButton);
+
+    await waitFor(() => expect(signOut).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem("accessToken")).toBeNull();
+    });
+  });
+
+  test("should navigate to the '/my-sketches' page when 'My Sketches' button is clicked", () => {
+    const { getByAltText, getByText } = render(<NavBar />);
+
+    const userImageButton = getByAltText("userImage");
+    fireEvent.click(userImageButton);
+
+    const mySketchesButton = getByText("My Sketches");
+    fireEvent.click(mySketchesButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/my-sketches");
+
+    expect(screen.queryByText("My Sketches")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 작업 요약
<img width="777" alt="스크린샷 2023-11-06 오후 2 11 58" src="https://github.com/team-desire/hello-sketch-client/assets/124029691/56306834-786b-4a0d-afd8-3fa62679e805">

## 참고 사항

- 테스트 중 콘솔에 에러가 발생하는 걸 막고자 아래 코드를 추가했습니다.
 - `window.alert = vi.fn();`
 -  src/components/NavBar line 24  `alert("error 발생")`;)으로 테스트코드에서  에러가 발생하는 것을 막고자 했습니다. 

## 체크 리스트

- [X] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [X] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [X] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
