### PR TITLE
[TASK-88] test: CanvasUnit 유닛 테스트 추가

### DIFF
--- a/src/components/CanvasUnit/index.jsx
+++ b/src/components/CanvasUnit/index.jsx
@@ -109,6 +109,7 @@ const CanvasUnit = forwardRef((props, ref) => {
         }}
       >
         <canvas
+          data-testid="canvas"
           ref={ref}
           width={location.width}
           height={location.height}

--- a/src/components/CanvasUnit/index.test.jsx
+++ b/src/components/CanvasUnit/index.test.jsx
@@ -28,9 +28,8 @@ const mockRef = {
 
 describe("CanvasUnit", () => {
   test("should initialize with the correct size", () => {
-    const { container } = render(<CanvasUnit {...mockProps} ref={mockRef} />);
-
-    const canvas = container.querySelector("canvas");
+    const { getByTestId } = render(<CanvasUnit ref={mockRef} {...mockProps} />);
+    const canvas = getByTestId("canvas");
 
     expect(canvas).toBeInTheDocument();
     expect(canvas).toHaveAttribute("width", `${mockProps.location.width}`);
@@ -38,9 +37,8 @@ describe("CanvasUnit", () => {
   });
 
   test("should render a canvas and interact with mouse events", async () => {
-    const { container } = render(<CanvasUnit {...mockProps} ref={mockRef} />);
-
-    const canvas = container.querySelector("canvas");
+    const { getByTestId } = render(<CanvasUnit ref={mockRef} {...mockProps} />);
+    const canvas = getByTestId("canvas");
 
     expect(canvas).toBeInTheDocument();
 

--- a/src/components/CanvasUnit/index.test.jsx
+++ b/src/components/CanvasUnit/index.test.jsx
@@ -1,0 +1,83 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+
+import CanvasUnit from "./index";
+
+const mockProps = {
+  svgData: '<svg><circle cx="50" cy="50" r="40" /></svg>',
+  fillColor: "red",
+  unitType: "SampleUnit",
+  parentWidth: 500,
+  parentHeight: 500,
+  location: {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+  },
+  onChangeLocation: vi.fn(),
+};
+
+const mockRef = {
+  current: {
+    getContext: vi.fn().mockReturnValue({
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+    }),
+  },
+};
+
+describe("CanvasUnit", () => {
+  test("should initialize with the correct size", () => {
+    const { container } = render(<CanvasUnit {...mockProps} ref={mockRef} />);
+
+    const canvas = container.querySelector("canvas");
+
+    expect(canvas).toBeInTheDocument();
+    expect(canvas).toHaveAttribute("width", `${mockProps.location.width}`);
+    expect(canvas).toHaveAttribute("height", `${mockProps.location.height}`);
+  });
+
+  test("should render a canvas and interact with mouse events", async () => {
+    const { container } = render(<CanvasUnit {...mockProps} ref={mockRef} />);
+
+    const canvas = container.querySelector("canvas");
+
+    expect(canvas).toBeInTheDocument();
+
+    fireEvent.mouseDown(canvas, { clientX: 0, clientY: 0 });
+
+    fireEvent.mouseMove(canvas, { clientX: 10, clientY: 10 });
+
+    await waitFor(() => expect(mockProps.onChangeLocation).toHaveBeenCalled());
+
+    fireEvent.mouseUp(canvas);
+  });
+
+  test("should resize canvas on range input change", async () => {
+    const { getByLabelText } = render(
+      <CanvasUnit ref={mockRef} {...mockProps} />,
+    );
+
+    const widthSlider = getByLabelText(`${mockProps.unitType} width:`);
+
+    fireEvent.change(widthSlider, { target: { value: 200 } });
+
+    await waitFor(() =>
+      expect(mockProps.onChangeLocation).toHaveBeenCalledWith({
+        ...mockProps.location,
+        width: 200,
+      }),
+    );
+
+    const heightSlider = getByLabelText(`${mockProps.unitType} height:`);
+
+    fireEvent.change(heightSlider, { target: { value: 200 } });
+
+    await waitFor(() =>
+      expect(mockProps.onChangeLocation).toHaveBeenCalledWith({
+        ...mockProps.location,
+        height: 200,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## 작업 요약
<img width="749" alt="스크린샷 2023-11-07 오후 2 48 57" src="https://github.com/team-desire/hello-sketch-client/assets/124029691/7bdf7246-b126-411d-b434-7e9783ec8f80">

## 참고 사항

- 소스 코드에 `dataTestId`를 추가하지 않고, `container`를 이용하여 특정 요소를 쿼리하고 테스트하였습니다.
  - [container 설명](https://testing-library.com/docs/react-testing-library/api/#container) 
  - [Role](https://www.w3.org/TR/html-aria/#docconformance) `canvas`에 해당하는 Role이 없어서 testId 사용 고려하였습니다. 
  - 소스코드에 testId를 추가하여 테스트하는 것이 좋지 않은 것 같아,  `container`을 이용한 방식으로 시도해봤습니다.
  
## 체크 리스트

- [X] [팀의 코딩 컨벤션](https://mirage-ceres-274.notion.site/ffe7df26591149768646f29af2a28a37?pvs=4)을 준수하였습니다.
- [X] PR 제목을 규칙에 맞게 작성하였습니다. (커밋 유형: ABC, 예시: feat: 로그인 기능 구현)
- [X] PR 라벨(FE/BE 여부, 커밋 유형)을 설정하였습니다.

---
